### PR TITLE
Adapt pivot when trying to fit to target

### DIFF
--- a/Assets/Coffee/UIExtensions/UnmaskForUGUI/Scripts/Unmask.cs
+++ b/Assets/Coffee/UIExtensions/UnmaskForUGUI/Scripts/Unmask.cs
@@ -130,6 +130,7 @@ namespace Coffee.UIExtensions
 		{
 			var rt = transform as RectTransform;
 
+                        rt.pivot = target.pivot;
 			rt.position = target.position;
 			rt.rotation = target.rotation;
 


### PR DESCRIPTION
When changing target which we want to be unmasked, when previous target had different pivot, it will cause unmasked part to be rendered incorrectly. If we adapt pivot to the new target it will be fixed