### PR TITLE
Pass camera to check the point in rectangle when camera is not null

### DIFF
--- a/Assets/Coffee/UIExtensions/UnmaskForUGUI/Scripts/UnmaskRaycastFilter.cs
+++ b/Assets/Coffee/UIExtensions/UnmaskForUGUI/Scripts/UnmaskRaycastFilter.cs
@@ -42,8 +42,15 @@ namespace Coffee.UIExtensions
 				return true;
 			}
 
-			// check inside
-			return !RectTransformUtility.RectangleContainsScreenPoint ((m_TargetUnmask.transform as RectTransform), sp);
+            // check inside
+            if (eventCamera)
+            {
+                return !RectTransformUtility.RectangleContainsScreenPoint((m_TargetUnmask.transform as RectTransform), sp, eventCamera);
+            }
+            else
+            {
+                return !RectTransformUtility.RectangleContainsScreenPoint((m_TargetUnmask.transform as RectTransform), sp);
+            }
 		}
 
 


### PR DESCRIPTION
To fix UnmaskRaycastFilter not working when Canvas render mode is set to Camera